### PR TITLE
Add support for setting User-Agent header string

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Based almost entirely on the excellent [foursquare](https://github.com/mLewisLog
 
 ## Usage
 
-    # Construct the client object
-    client = untappd.Untappd(client_id='YOUR_CLIENT_ID', client_secret='YOUR_CLIENT_SECRET', redirect_url='YOUR_REDIRECT_URL')
+    # Construct the client object (user_agent is optional, at least 'authorize' endpoint responds with 'HTTP 429 Too Many Requests' to default User-Agent header string like 'python-requests/2.24.0')
+    client = untappd.Untappd(client_id='YOUR_CLIENT_ID', client_secret='YOUR_CLIENT_SECRET', redirect_url='YOUR_REDIRECT_URL', user_agent='letmein')
 
 ### Authentication
 


### PR DESCRIPTION
https://untappd.com/api/docs#start

>Please note that you must provide a non-standard User Agent for all requests using the API (including authentication). Your user-agent can include your app name and Client ID, such as "Greg's App (CLIENT_ID)", however can be customized for your needs. Do not use standard user-agents, always indentify your self.

Otherwise at least `authorize` endpoint responds with `HTTP 429 Too Many Requests` to default User-Agent header string like `python-requests/2.24.0`. So now we can set it to what we want and use it anyways. `letmein` works btw :)