### PR TITLE
Add view endpoint for Checkin

### DIFF
--- a/untappd/__init__.py
+++ b/untappd/__init__.py
@@ -244,7 +244,7 @@ class Untappd(object):
     class Checkin(_Endpoint):
         """Checkin endpoint class"""
         endpoint_base = 'checkin'
-        get_endpoints = ('recent',)
+        get_endpoints = ('recent', 'view')
         post_endpoints = ('add', 'toast', 'addcomment', 'deletecomment')
 
     class Friend(_Endpoint):


### PR DESCRIPTION
Per the Untappd API explorer, there is a `view` endpoint for a `checkin`. The explorer example is `https://api.untappd.com/v4/checkin/view/10888893`